### PR TITLE
closed #923 fix image size of users/icon

### DIFF
--- a/app/assets/stylesheets/projects/index.css.scss
+++ b/app/assets/stylesheets/projects/index.css.scss
@@ -15,14 +15,16 @@
     font-family: $common-novelsans-semibold;
     .image-wrapper {
       display: block;
-      margin-left: $border_margin;
-      width: $left_pane_width - $border_margin * 2;
+      width: $left_pane_width;
+      height: $left_pane_width;
       .owner-avatar {
-        margin-bottom: 20px;
-        max-width: 100%;
+        position: relative;
         border-radius: $left_pane_width - $border_margin * 2;
+        width: $left_pane_width - $border_margin * 2;
+        height: $left_pane_width - $border_margin * 2;
         border: $border_margin solid white;
-        margin: -$border_margin;
+        background-position: center center;
+        background-size: cover;
         z-index: 11111;
       }
     }

--- a/app/views/projects/index.html.slim
+++ b/app/views/projects/index.html.slim
@@ -4,7 +4,7 @@
 #projects-index
   .left
     .image-wrapper
-      == image_tag @owner.avatar, class: "owner-avatar"
+      .owner-avatar style="background-image: url('#{@owner.avatar}')"
 
     .wrapper
       .owner-name


### PR DESCRIPTION
アイコンサイズを統一しました。
縦横比が1:1でない画像は短い辺に合わせて中央を表示します。
![tate_diff](https://cloud.githubusercontent.com/assets/4831340/7178006/65cebf94-e466-11e4-8ccc-c07585cbae52.png)
![64px_diff](https://cloud.githubusercontent.com/assets/4831340/7177999/54998524-e466-11e4-83a4-2d2395d9227a.png)
![yoko_diff](https://cloud.githubusercontent.com/assets/4831340/7178042/b7d2b282-e466-11e4-8b7c-c0e0d5e1dc36.png)
