### PR TITLE
close #1147 Add "youtu.be" URL support.

### DIFF
--- a/app/assets/javascripts/card.js.coffee
+++ b/app/assets/javascripts/card.js.coffee
@@ -381,17 +381,18 @@ $ ->
       if index != length - 1
         $(element).find(".delete.btn").find("a").trigger "click"
 
-  YOUTUBE_URL_MIN_LENGTH   = 41
+  YOUTUBE_URL_MIN_LENGTH   = 28
   YOUTUBE_EMBED_URL_BASE   = "http://www.youtube.com/embed/"
   # TODO: constantize '11'
-  YOUTUBE_WATCH_URL_REGEXP = /https?:\/\/(?:www\.)?youtube.com\/watch\?v=([^&]{11,})(&\S*)?$/
+  # This expression matches domains both youtube.com and youtu.be
+  YOUTUBE_WATCH_URL_REGEXP = /https?:\/\/(?:(?:youtu\.be\/)|(?:www\.)?(?:youtube\.com\/watch\?v=))([^&]{11,})(&\S*)?$/
   VIDEOID_MATCH_INDEX      = 1
 
   getVideoForCard = ->
     url = $(this).val()
     if previous_url != url
       previous_url = url
-      if url.length > YOUTUBE_URL_MIN_LENGTH
+      if url.length >= YOUTUBE_URL_MIN_LENGTH
         if matched = url.match YOUTUBE_WATCH_URL_REGEXP
           video_id_for_card = matched[VIDEOID_MATCH_INDEX]
           embed_url = YOUTUBE_EMBED_URL_BASE + video_id_for_card
@@ -402,7 +403,7 @@ $ ->
           $("#inner_content .caution").text "Invalid YouTube URL"
           disableSubmitButtonForItems()
       else
-        $("#inner_content .caution").text "URL is too short. URL length = #{url.length}. Min length = 42."
+        $("#inner_content .caution").text "URL is too short. URL length = #{url.length}. Min length = #{YOUTUBE_URL_MIN_LENGTH}."
         disableSubmitButtonForItems()
 
   $(document).on "click", "#inner_content .submit", (event) ->

--- a/app/assets/javascripts/project_form.js.coffee
+++ b/app/assets/javascripts/project_form.js.coffee
@@ -17,17 +17,18 @@ $ ->
     $("#recipes-edit iframe").attr "src", ""
     $("#recipes-edit .submit").attr "disabled", true
 
-  YOUTUBE_URL_MIN_LENGTH   = 41
+  YOUTUBE_URL_MIN_LENGTH   = 28
   YOUTUBE_EMBED_URL_BASE   = "http://www.youtube.com/embed/"
   # TODO: constantize '11'
-  YOUTUBE_WATCH_URL_REGEXP = /https?:\/\/(?:www\.)?youtube.com\/watch\?v=([^&]{11,})(&\S*)?$/
+  # This expression matches domains both youtube.com and youtu.be
+  YOUTUBE_WATCH_URL_REGEXP = /https?:\/\/(?:(?:youtu\.be\/)|(?:www\.)?(?:youtube\.com\/watch\?v=))([^&]{11,})(&\S*)?$/
   VIDEOID_MATCH_INDEX      = 1
 
   getVideoForProject = ->
     url = $(this).val()
     if previous_url != url
       previous_url = url
-      if url.length > YOUTUBE_URL_MIN_LENGTH
+      if url.length >= YOUTUBE_URL_MIN_LENGTH
         if matched = url.match YOUTUBE_WATCH_URL_REGEXP
           video_id_for_card = matched[VIDEOID_MATCH_INDEX]
           embed_url = YOUTUBE_EMBED_URL_BASE + video_id_for_card
@@ -38,7 +39,7 @@ $ ->
           $("main#recipes-edit .caution").text "Invalid YouTube URL"
           disableSubmitButtonForItems()
       else
-        $("main#recipes-edit .caution").text "URL is too short. URL length = #{url.length}. Min length = 42."
+        $("main#recipes-edit .caution").text "URL is too short. URL length = #{url.length}. Min length = #{YOUTUBE_URL_MIN_LENGTH}."
         disableSubmitButtonForItems()
 
   $(document).on "click", "#recipes-new .submit", (event) ->


### PR DESCRIPTION
Feature request #1147 

Reason:
YouTube gives share URL of videos as “https://youtu.be/{id}” .

Valid URL
https://youtu.be/QmjSb48yVO8
http://youtube.com/watch?v=QmjSb48yVO8
https://www.youtube.com/watch?v=QmjSb48yVO8&list=PL7QOwp8NKs9dKqNsgl382n
RXT_iBfzKY6

Invalid URL
https://youtu.be/QmjSb4
https://youtu.be.com/QmjSb48yVO8
ssh://www.youtube.com/watch?v=QmjSb48yVO8